### PR TITLE
Fix timing in docs/index.html

### DIFF
--- a/docs/index.html.bak
+++ b/docs/index.html.bak
@@ -75,7 +75,7 @@
         ctx     = canvas.getContext('2d'),
         ucanvas = get('upcoming'),
         uctx    = ucanvas.getContext('2d'),
-        speed   = { start: 0.6, decrement: 0.005, min: 0.1 }, // how long before piece drops by 1 row (seconds)
+        speed   = { start: 1000.6, decrement: 0.005, min: 1.1 }, // how long before piece drops by 1 row (seconds)
         nx      = 10, // width of tetris court (in blocks)
         ny      = 20, // height of tetris court (in blocks)
         nu      = 5;  // width/height of upcoming preview (in blocks)


### PR DESCRIPTION
This commit fixes the timing error in docs/index.html by setting correct start and min properties for the speed object.

This commit fixes #6